### PR TITLE
Added crude instr. on how to install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 
     $ sudo pacman -S dosbox inotify-tools timidity++ soundfont-fluid
 
-
 ## Installation (using tarball)
 
 1. Close Steam.
@@ -59,6 +58,25 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 
        $ cd ~/.local/share/Steam/compatibilitytools.d/ || cd ~/.steam/root/compatibilitytools.d/
        $ curl -L https://github.com/dreamer/steam-dos/releases/download/v0.4.0/steam-dos.tar.xz | tar xJf -
+
+3. Start Steam.
+4. In game properties window select "Force the use of a specific Steam Play
+   compatibility tool" and select "DOSBox (native)".
+
+## Installation (from source)
+
+0. Install extra prerequisites.
+
+#### Arch, Manjaro
+
+    $ sudo pacman -S git shellcheck python-pylint python-pyenchant hunspell-en_GB
+
+1. Close Steam.
+2. Clone the repository and install the script to user directory:
+
+       $ git clone https://github.com/dreamer/steam-dos.git
+       $ cd steam-dos
+       $ make user-install
 
 3. Start Steam.
 4. In game properties window select "Force the use of a specific Steam Play

--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 
 ## Installation (from source)
 
-0. Install extra prerequisites.
-
-#### Arch, Manjaro
-
-    $ sudo pacman -S git shellcheck python-pylint python-pyenchant hunspell-en_GB
-
 1. Close Steam.
 2. Clone the repository and install the script to user directory:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 
     $ sudo pacman -S dosbox inotify-tools timidity++ soundfont-fluid
 
+
 ## Installation (using tarball)
 
 1. Close Steam.
@@ -62,6 +63,7 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 3. Start Steam.
 4. In game properties window select "Force the use of a specific Steam Play
    compatibility tool" and select "DOSBox (native)".
+
 
 ## Installation (from source)
 
@@ -81,6 +83,7 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 3. Start Steam.
 4. In game properties window select "Force the use of a specific Steam Play
    compatibility tool" and select "DOSBox (native)".
+
 
 ## Configuration
 
@@ -152,9 +155,11 @@ For example, to start King's Quest 6 from
 Check `SierraLauncher.ini` file in game's installation dir to learn which number
 corresponds to which game.
 
+
 ## Development
 
 Read all about it in the [contributing guide](https://github.com/dreamer/steam-dos/blob/master/CONTRIBUTING.md) :)
+
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Optionally for MIDI support: TiMidity++ or FluidSynth and a soundfont.
 
 3. Start Steam.
 4. In game properties window select "Force the use of a specific Steam Play
-   compatibility tool" and select "DOSBox (native)".
+   compatibility tool" and select "steam-dos (git)".
 
 
 ## Configuration


### PR DESCRIPTION
Added crude instructions on how to install from source, with dependencies so far only for Arch et al. May require checking if all dependencies are properly listed and could probably be rearranged to avoid duplication